### PR TITLE
Use phpspec v2.1.1 to fix #2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php":             ">=5.4",
-        "phpspec/phpspec": "~2.0",
+        "phpspec/phpspec": "~2.1.1",
         "rmiller/caser":   "~0.1"
     },
     "require-dev": {


### PR DESCRIPTION
`phpspec/phpspec` latest version v `2.1.1` solves "`DialogHelper is deprecated`" problem.

Is this a solution for #2?